### PR TITLE
Rotation functionality

### DIFF
--- a/changelog/6.feature.rst
+++ b/changelog/6.feature.rst
@@ -1,0 +1,1 @@
+Created :meth:`~sunkit_pyvista.plotter.SunpyPlotter.rotate` which allows for rotating a :class:`~sunpy.map.GenericMap` by a specified angle.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,31 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
+# Enable nitpicky mode, which forces links to be non-broken
+nitpicky = True
+nitpick_ignore = [
+    # Prevents shpinx nitpicky mode picking up on optional
+    # (see https://github.com/sphinx-doc/sphinx/issues/6861)
+    ('py:class', 'optional'),
+    # See https://github.com/numpy/numpy/issues/10039
+    ('py:obj', 'numpy.datetime64'),
+    # There's no specific file or function classes to link to
+    ('py:class', 'file object'),
+    ('py:class', 'function'),
+    ('py:obj', 'function'),
+    ('py:class', 'any type'),
+    ('py:class', "Unit('pix')"),
+    ('py:class', "Unit('deg')"),
+    ('py:class', "Unit('arcsec')"),
+    ('py:class', "Unit('%')"),
+    ('py:class', "Unit('s')"),
+    ('py:class', "Unit('Angstrom')"),
+    ('py:class', "Unit('arcsec / pix')"),
+    ('py:class', "Unit('W / m2')"),
+    ('py:class', 'array-like'),
+    ('py:obj', 'parfive'),
+]
+
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -1,7 +1,7 @@
 """
-=======================================
-Three dimensional plots with sunpy Maps
-=======================================
+======================
+Rotation of sunpy Maps
+======================
 
 Using sunkit-pyvista, one can interface with the `pyvista` package to
 produce interactive 3D plots for sunpy Maps.

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -1,7 +1,7 @@
 """
-======================
-Rotation of sunpy Maps
-======================
+=======================================
+Three dimensional plots with sunpy Maps
+=======================================
 
 Using sunkit-pyvista, one can interface with the `pyvista` package to
 produce interactive 3D plots for sunpy Maps.

--- a/examples/skip_rotating_maps.py
+++ b/examples/skip_rotating_maps.py
@@ -3,8 +3,8 @@
 Three dimensional plots with sunpy Maps
 =======================================
 
-Using sunkit-pyvista, one can interface with the `pyvista` package to
-produce interactive 3D plots for sunpy Maps.
+sunkit-pyvista also allows for rotation of maps to render the initial plot with the
+specified angle.
 """
 import pyvista as pv
 
@@ -16,16 +16,11 @@ from sunpy.map import Map
 
 from sunkit_pyvista import SunpyPlotter
 
-pv.start_xvfb()
+# pv.start_xvfb()
 
 ###############################################################################
-# We will firstly use an AIA 193 image from the sunpy sample data as the base image.
+# Import some sample data
 m = Map(AIA_193_IMAGE)
-
-###############################################################################
-# 3D plots are done on "plotter" objects, which are similar to matplotlib axes.
-# sunkit-pyvista has a built in `SunpyPlotter` class that can be used to plot maps
-# and coordinate aware objects.
 
 # Start by creating a plotter
 plotter = SunpyPlotter()
@@ -39,5 +34,9 @@ line = SkyCoord(lon=[180, 190, 200] * u.deg,
                 distance=[1, 2, 3] * const.R_sun,
                 frame='heliocentricinertial')
 plotter.plot_line(line)
+
+# `SunpyPlotter` provides a rotate method which accepts an angle. This rotates
+# all the rendered meshes to be rotated by that particular angle.
+plotter.rotate(angle=30 * u.deg)
 
 plotter.show(cpos=(-100, 0, 0))

--- a/examples/skip_rotating_maps.py
+++ b/examples/skip_rotating_maps.py
@@ -6,7 +6,6 @@ Three dimensional plots with sunpy Maps
 sunkit-pyvista also allows for rotation of maps to render the initial plot with the
 specified angle.
 """
-import pyvista as pv
 
 import astropy.constants as const
 import astropy.units as u

--- a/examples/skip_rotating_maps.py
+++ b/examples/skip_rotating_maps.py
@@ -6,6 +6,7 @@ Rotation of sunpy Maps
 sunkit-pyvista also allows for rotation of maps to render the initial plot with the
 specified angle.
 """
+import pyvista as pv
 
 import astropy.constants as const
 import astropy.units as u

--- a/examples/skip_rotating_maps.py
+++ b/examples/skip_rotating_maps.py
@@ -1,7 +1,7 @@
 """
-=======================================
-Three dimensional plots with sunpy Maps
-=======================================
+======================
+Rotation of sunpy Maps
+======================
 
 sunkit-pyvista also allows for rotation of maps to render the initial plot with the
 specified angle.
@@ -15,7 +15,7 @@ from sunpy.map import Map
 
 from sunkit_pyvista import SunpyPlotter
 
-# pv.start_xvfb()
+pv.start_xvfb()
 
 ###############################################################################
 # Import some sample data

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -91,7 +91,7 @@ class SunpyPlotter:
 
         Parameters
         ----------
-        m : sunpy.map.Map
+        m : `sunpy.map.Map`
             Map to be plotted.
         **kwargs :
             Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
@@ -107,7 +107,7 @@ class SunpyPlotter:
 
         Parameters
         ----------
-        coords : astropy.coordinates.SkyCoord
+        coords : `astropy.coordinates.SkyCoord`
             Coordinates to plot as a line.
         **kwargs :
             Keyword arguments are passed to `pyvista.Plotter.add_mesh`.

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -2,8 +2,8 @@ import functools
 
 import numpy as np
 import pyvista as pv
-import astropy.units as u
 
+import astropy.units as u
 from astropy.constants import R_sun
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map.maputils import all_corner_coords_from_map
@@ -140,14 +140,13 @@ class SunpyPlotter:
                     'tip_radius': 0.02}
         defaults.update(arrow_kwargs)
         solar_axis = pv.Arrow(start=(0, 0, -length / 2),
-                         direction=(0, 0, length),
-                         scale='auto',
-                         **defaults)
+                              direction=(0, 0, length),
+                              scale='auto',
+                              **defaults)
         self.plotter.add_mesh(solar_axis, **kwargs)
         self.meshes.append(solar_axis)
 
-    def rotate(self, angle : u = 0.0*u.deg):
+    def rotate(self, angle: u = 0.0 * u.deg):
         rotation_angle = angle.to_value(u.deg)
         for mesh in self.meshes:
             mesh.rotate_x(rotation_angle)
-


### PR DESCRIPTION
The easiest way rotation could be implemented in Pyvista without having to handle the camera's coordinates and line of sight.
This requires the class to keep track of all the meshes used because once `add_mesh` is called, there's no way to get a reference to it
The initial plot with a rotation of 30*u.deg is 
![image](https://user-images.githubusercontent.com/50923538/120204254-39e8f600-c246-11eb-97cc-7dd03873dd74.png)
