### PR TITLE
Adds ability to plot Pfsspy field lines

### DIFF
--- a/changelog/12.feature.rst
+++ b/changelog/12.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`~sunkit_pyvista.plotter.SunpyPlotter.plot_field_lines` method which allows for plotting of magnetic field lines from `pfsspy` through pyvista.

--- a/examples/skip_plot_field_lines.py
+++ b/examples/skip_plot_field_lines.py
@@ -3,7 +3,7 @@
 Plotting Field Lines from pfsspy
 ================================
 
-sunkit-pyvista and can also be used to plot field lines from `pfsspy`.
+sunkit-pyvista can be used to plot field lines from `pfsspy`.
 """
 
 import numpy as np

--- a/examples/skip_plot_field_lines.py
+++ b/examples/skip_plot_field_lines.py
@@ -7,9 +7,13 @@ Sunkit-pyvista and can also be used to plot field lines from `pfsspy`.
 """
 
 import numpy as np
+import pfsspy
+from pfsspy import tracing
 from pfsspy.sample_data import get_gong_map
 
 import astropy.units as u
+from astropy.constants import R_sun
+from astropy.coordinates import SkyCoord
 from sunpy.data.sample import AIA_193_IMAGE
 from sunpy.map import Map
 
@@ -41,12 +45,18 @@ lat = np.linspace(-np.pi / 2, np.pi / 2, 8, endpoint=False)
 lon = np.linspace(0, 2 * np.pi, 8, endpoint=False)
 # Make a 2D grid from these 1D points
 lat, lon = np.meshgrid(lat, lon, indexing='ij')
-
-# Create lon, lat and radial coordinate values by using a pfsspy map.
+# Create lon, lat and radial coordinate values by using a pfsspy
+# and trace them using tracer
 lat, lon = lat.ravel() * u.rad, lon.ravel() * u.rad
 radius = 1.2
+tracer = tracing.PythonTracer()
+input_ = pfsspy.Input(gong_map, nrho, rss)
+output_ = pfsspy.pfss(input_)
+seeds = SkyCoord(lon, lat, radius*R_sun,
+                 frame=gong_map.coordinate_frame)
+field_lines = tracer.trace(seeds, output_)
 
 # We plot the field lines
-plotter.plot_field_lines(gong_map, lon, lat, radius, nrho, rss)
+plotter.plot_field_lines(field_lines)
 
 plotter.show()

--- a/examples/skip_plot_field_lines.py
+++ b/examples/skip_plot_field_lines.py
@@ -1,0 +1,54 @@
+"""
+=======================================
+Three dimensional plots with sunpy Maps
+=======================================
+
+Sunkit-pyvista and can also be used to plot field lines from `pfsspy`.
+"""
+
+import astropy.constants as const
+import astropy.units as u
+import numpy as np
+
+from astropy.coordinates import SkyCoord
+from sunpy.data.sample import AIA_193_IMAGE
+from sunpy.map import Map
+
+from sunkit_pyvista import SunpyPlotter
+from pfsspy.sample_data import get_gong_map
+
+###############################################################################
+# We will firstly use an AIA 193 image from the sunpy sample data as the base image.
+m = Map(AIA_193_IMAGE)
+
+# Start by creating a plotter
+plotter = SunpyPlotter()
+
+# Plot a map
+plotter.plot_map(m)
+# Add an arrow to show the solar rotation axis
+plotter.plot_solar_axis()
+
+# We load a gong_map from pfsspy
+gong_fname = get_gong_map()
+gong_map = Map(gong_fname)
+
+# Define the number of grid points in rho and solar surface rarius
+nrho = 35
+rss = 2.5
+
+# Create 5 points spaced between lat={-90, 90} degrees
+lat = np.linspace(-np.pi / 2, np.pi / 2, 8, endpoint=False)
+# Create 5 points spaced between long={0, 180} degrees
+lon = np.linspace(0, 2 * np.pi, 8, endpoint=False)
+# Make a 2D grid from these 1D points
+lat, lon = np.meshgrid(lat, lon, indexing='ij')
+
+# Create lon, lat and radial coordinate values by using a pfsspy map.
+lat, lon = lat.ravel() * u.rad, lon.ravel() * u.rad
+radius = 1.2
+
+# We plot the field lines
+plotter.plot_field_lines(gong_map, lon, lat, radius, nrho, rss)
+
+plotter.show()

--- a/examples/skip_plot_field_lines.py
+++ b/examples/skip_plot_field_lines.py
@@ -6,16 +6,14 @@ Plotting Field Lines from Pfsspy
 Sunkit-pyvista and can also be used to plot field lines from `pfsspy`.
 """
 
-import astropy.constants as const
-import astropy.units as u
 import numpy as np
+from pfsspy.sample_data import get_gong_map
 
-from astropy.coordinates import SkyCoord
+import astropy.units as u
 from sunpy.data.sample import AIA_193_IMAGE
 from sunpy.map import Map
 
 from sunkit_pyvista import SunpyPlotter
-from pfsspy.sample_data import get_gong_map
 
 ###############################################################################
 # We will firstly use an AIA 193 image from the sunpy sample data as the base image.

--- a/examples/skip_plot_field_lines.py
+++ b/examples/skip_plot_field_lines.py
@@ -1,7 +1,7 @@
 """
-=======================================
-Three dimensional plots with sunpy Maps
-=======================================
+================================
+Plotting Field Lines from Pfsspy
+================================
 
 Sunkit-pyvista and can also be used to plot field lines from `pfsspy`.
 """

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -16,7 +16,6 @@ from sunpy.map import Map
 
 from sunkit_pyvista import SunpyPlotter
 
-pv.start_xvfb()
 
 ###############################################################################
 # We will firstly use an AIA 193 image from the sunpy sample data as the base image.
@@ -39,5 +38,6 @@ line = SkyCoord(lon=[180, 190, 200] * u.deg,
                 distance=[1, 2, 3] * const.R_sun,
                 frame='heliocentricinertial')
 plotter.plot_line(line)
-
+plotter.pfss()
 plotter.show(cpos=(-100, 0, 0))
+

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -6,7 +6,6 @@ Three dimensional plots with sunpy Maps
 Using sunkit-pyvista, one can interface with the `pyvista` package to
 produce interactive 3D plots for sunpy Maps.
 """
-import pyvista as pv
 
 import astropy.constants as const
 import astropy.units as u
@@ -15,7 +14,6 @@ from sunpy.data.sample import AIA_193_IMAGE
 from sunpy.map import Map
 
 from sunkit_pyvista import SunpyPlotter
-
 
 ###############################################################################
 # We will firstly use an AIA 193 image from the sunpy sample data as the base image.
@@ -38,6 +36,4 @@ line = SkyCoord(lon=[180, 190, 200] * u.deg,
                 distance=[1, 2, 3] * const.R_sun,
                 frame='heliocentricinertial')
 plotter.plot_line(line)
-plotter.pfss()
 plotter.show(cpos=(-100, 0, 0))
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ setup_requires =
 install_requires =
   pyvista>=0.30.1
   sunpy[map]>=3.0.0
+  pfsspy>=0.6.6
 
 [options.extras_require]
 tests =

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -178,4 +178,4 @@ class SunpyPlotter:
         grid_data = np.concatenate(grid_data)
         field_line_mesh = pv.StructuredGrid(grid_data[:, 0], grid_data[:, 1], grid_data[:, 2])
 
-        self.plotter.add_mesh(field_line_mesh)
+        self.plotter.add_mesh(field_line_mesh, kwargs)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -145,7 +145,7 @@ class SunpyPlotter:
                          **defaults)
         self.plotter.add_mesh(arrow, **kwargs)
 
-    def plot_field_lines(self, gong_map, lon, lat, radius, nrho=25, rss=2.5):
+    def plot_field_lines(self, gong_map, lon, lat, radius, nrho=25, rss=2.5, **kwargs):
         """
         Plots the field lines from `pfsspy`.
 
@@ -158,6 +158,8 @@ class SunpyPlotter:
         radius : `float`
         nrho : `int`
         rss : `int`
+        **kwargs :
+            Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """
         tracer = tracing.PythonTracer()
         input_ = pfsspy.Input(gong_map, nrho, rss)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -30,7 +30,6 @@ class SunpyPlotter:
             coordinate_frame = HeliocentricInertial()
         self._coordinate_frame = coordinate_frame
         self._plotter = pv.Plotter()
-        self._plotter.show_axes()
 
     @property
     def coordinate_frame(self):

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -181,4 +181,5 @@ class SunpyPlotter:
         for field_line in field_lines:
             grid = self._coords_to_xyz(field_line.coords.ravel())
             field_line_mesh = pv.StructuredGrid(grid[:, 0], grid[:, 1], grid[:, 2])
-            self.plotter.add_mesh(field_line_mesh, **kwargs)
+            color = {0: 'black', -1: 'tab:blue', 1: 'tab:red'}.get(field_line.polarity)
+            self.plotter.add_mesh(field_line_mesh, color=color, **kwargs)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -1,12 +1,9 @@
 import functools
 
 import numpy as np
-import pfsspy
 import pyvista as pv
-from pfsspy import tracing
 
 from astropy.constants import R_sun
-from astropy.coordinates import SkyCoord
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map.maputils import all_corner_coords_from_map
 
@@ -145,37 +142,18 @@ class SunpyPlotter:
                          **defaults)
         self.plotter.add_mesh(arrow, **kwargs)
 
-    def plot_field_lines(self, gong_map, lon, lat, radius, nrho=25, rss=2.5, **kwargs):
+    def plot_field_lines(self, field_lines, **kwargs):
         """
         Plots the field lines from `pfsspy`.
 
         Parameters
         ----------
-        gong_map : `pfsspy.map.GongSynopticMap`
-            to produce the field lines
-        lon : `astropy.units.quantity`
-        lat : `astropy.units.quantity`
-        radius : `float`
-        nrho : `int`
-        rss : `int`
+        field_lines : `pfsspy.fieldline.FieldLines`
+            Field lines to be plotted
         **kwargs :
             Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """
-        tracer = tracing.PythonTracer()
-        input_ = pfsspy.Input(gong_map, nrho, rss)
-        output_ = pfsspy.pfss(input_)
-
-        seeds = SkyCoord(lon, lat, radius*R_sun,
-                         frame=gong_map.coordinate_frame)
-
-        field_lines = tracer.trace(seeds, output_)
-        grid_data = []
-
         for field_line in field_lines:
             grid = self._coords_to_xyz(field_line.coords.ravel())
-            grid_data.append(grid)
-
-        grid_data = np.concatenate(grid_data)
-        field_line_mesh = pv.StructuredGrid(grid_data[:, 0], grid_data[:, 1], grid_data[:, 2])
-
-        self.plotter.add_mesh(field_line_mesh, kwargs)
+            field_line_mesh = pv.StructuredGrid(grid[:, 0], grid[:, 1], grid[:, 2])
+            self.plotter.add_mesh(field_line_mesh, **kwargs)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -174,7 +174,7 @@ class SunpyPlotter:
         Parameters
         ----------
         field_lines : `pfsspy.fieldline.FieldLines`
-            Field lines to be plotted
+            Field lines to be plotted.
         **kwargs :
             Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """


### PR DESCRIPTION
A rough draft on adding functionality to plot field lines.
Most of the field creation of the lon, lat and and radius values are done in the example file and I'm not sure this is how we want it structured here.
Should we allow `plot_field_lines` method to accept Skycoord only as an argument and directly plot the field lines instead of creating the Skycoord with the `lon`, `lat` and `r` values being passed to SkyCood?

- [x] Specifying colors to the mesh