### PR TITLE
Removed rotation functionality

### DIFF
--- a/changelog/10.feature.rst
+++ b/changelog/10.feature.rst
@@ -1,1 +1,1 @@
-Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.set_camera_coordinates` which allows for specifying the initial camera coordinates.
+Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.set_camera_coordinate` which allows for specifying the initial camera coordinates.

--- a/changelog/10.feature.rst
+++ b/changelog/10.feature.rst
@@ -1,2 +1,1 @@
 Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.set_camera_coordinates` which allows for specifying the initial camera coordinates.
-

--- a/changelog/10.feature.rst
+++ b/changelog/10.feature.rst
@@ -1,2 +1,2 @@
 Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.set_camera_coordinates` which allows for specifying the initial camera coordinates.
-Creation of :meth:`~sunkit_pyvista.plotter.SunpyPlotter.rotate_camera` which allows for rotation of the plot by the specified angle.
+

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -42,7 +42,4 @@ plotter.plot_line(line)
 camera_position = SkyCoord(0*u.deg, 0*u.deg, 8*const.R_sun, obstime=m.observer_coordinate.obstime, frame=frames.HeliographicStonyhurst)
 plotter.set_camera_coordinates(camera_position)
 
-# Rotate the camera by a given angle
-plotter.rotate_camera(45*u.deg)
-
 plotter.show()

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -59,7 +59,7 @@ class SunpyPlotter:
                                 coords.y.to_value(R_sun),
                                 coords.z.to_value(R_sun)))
 
-    def set_camera_coordinates(self, coord):
+    def set_camera_coordinate(self, coord):
         """
         Sets the inital camera position of the rendered plot.
 

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -3,7 +3,6 @@ import functools
 import numpy as np
 import pyvista as pv
 
-import astropy.units as u
 from astropy.constants import R_sun
 from sunpy.coordinates import HeliocentricInertial
 from sunpy.map.maputils import all_corner_coords_from_map

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -73,18 +73,6 @@ class SunpyPlotter:
         pos = tuple(camera_position[0])
         self.plotter.camera.position = pos
 
-    def rotate_camera(self, angle: u.deg = None):
-        """
-        Rotates the camera by the specified value in degrees.
-
-        Parameters
-        ----------
-        angle : `astropy.units.Quantity`
-            The angle of rotation.
-        """
-        rotation_angle = angle.to_value(u.deg)
-        self.plotter.camera.roll = rotation_angle
-
     def _pyvista_mesh(self, m):
         """
         Create a mesh from a map.


### PR DESCRIPTION
Removes rotation functionality as we can manually point to PyVista's docs instead.
This example would have to be added separately.
Also fixes #13