### PR TITLE
Adds draw_quadrangle method

### DIFF
--- a/changelog/17.feature.rst
+++ b/changelog/17.feature.rst
@@ -1,2 +1,2 @@
-Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.draw_quadrangle` which allows for specifying drawing a drawing a quadrangle defined
+Adds :meth:`~sunkit_pyvista.plotter.SunpyPlotter.plot_quadrangle` which allows for specifying drawing a drawing a quadrangle defined
 by coordinates passed to it.

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -10,6 +10,7 @@ produce interactive 3D plots for sunpy Maps.
 import astropy.constants as const
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from sunpy.coordinates import frames
 from sunpy.data.sample import AIA_193_IMAGE
 from sunpy.map import Map
 
@@ -45,5 +46,5 @@ plotter.set_view_angle(m.rsun_obs)
 bottom_left = SkyCoord(30*u.deg, -10*u.deg,
                        frame=frames.HeliographicStonyhurst,
                        obstime=m.date)
-plotter.plot_quadrangle(m, bottom_left=bottom_left, width=20*u.deg, height=60*u.deg, color='blue')
+plotter.plot_quadrangle(bottom_left=bottom_left, width=20*u.deg, height=60*u.deg, color='blue')
 plotter.show()

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -40,7 +40,7 @@ plotter.plot_line(line)
 
 # Define a SkyCoord for to set the positon of the camera
 camera_position = SkyCoord(0*u.deg, 0*u.deg, 8*const.R_sun, obstime=m.observer_coordinate.obstime, frame=frames.HeliographicStonyhurst)
-plotter.set_camera_coordinates(camera_position)
+plotter.set_camera_coordinate(camera_position)
 
 # Plot a quadrangle with width of 20 degrees and a height of 60 degrees
 bottom_left = SkyCoord(30*u.deg, -10*u.deg,

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -43,5 +43,12 @@ camera_position = SkyCoord(0*u.deg, 0*u.deg, 8*const.R_sun, obstime=m.observer_c
 plotter.set_camera_coordinates(camera_position)
 
 # Rotate the camera by a given angle
-plotter.rotate_camera(45*u.deg)
+# plotter.rotate_camera(45*u.deg)
+# plotter.show()
+
+# Plot a quadrangle with width of 20 degrees and a height of 60 degrees
+bottom_left = SkyCoord(30*u.deg, -10*u.deg,
+                       frame=frames.HeliographicStonyhurst,
+                       obstime=m.date)
+plotter.plot_quadrangle(m, bottom_left=bottom_left, width=20*u.deg, height=60*u.deg, color='blue')
 plotter.show()

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -44,5 +44,4 @@ plotter.set_camera_coordinates(camera_position)
 
 # Rotate the camera by a given angle
 plotter.rotate_camera(45*u.deg)
-
 plotter.show()

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -38,14 +38,8 @@ line = SkyCoord(lon=[180, 190, 200] * u.deg,
 plotter.plot_line(line)
 plotter.set_camera_coordinate(m.observer_coordinate)
 
-<<<<<<< HEAD
-# Define a SkyCoord for to set the positon of the camera
-camera_position = SkyCoord(0*u.deg, 0*u.deg, 8*const.R_sun, obstime=m.observer_coordinate.obstime, frame=frames.HeliographicStonyhurst)
-plotter.set_camera_coordinate(camera_position)
-=======
 # Set the view angle of the plot
 plotter.set_view_angle(m.rsun_obs)
->>>>>>> f23a1b847882b4a820de12e0ede9bbdfa4d7e1b5
 
 # Plot a quadrangle with width of 20 degrees and a height of 60 degrees
 bottom_left = SkyCoord(30*u.deg, -10*u.deg,

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -5,7 +5,7 @@ import pyvista as pv
 
 import astropy.units as u
 from astropy.constants import R_sun
-from sunpy.coordinates import HeliocentricInertial
+from sunpy.coordinates import HeliocentricInertial, SkyCoord
 from sunpy.map.maputils import all_corner_coords_from_map
 
 __all__ = ['SunpyPlotter']
@@ -166,3 +166,27 @@ class SunpyPlotter:
                          scale='auto',
                          **defaults)
         self.plotter.add_mesh(arrow, **kwargs)
+
+    def plot_quadrangle(self, m, bottom_left, top_right, width, height, **kwargs):
+        """
+        Plots a quadrangle on the given map.
+        This draws a quadrangle that has corners at ``(bottom_left, top_right)``,
+        if ``width`` and ``height`` are specified, they are respectively added to the
+        longitude and latitude of the ``bottom_left`` coordinate to calculate a
+        ``top_right`` coordinate.
+
+        Parameters
+        ----------
+        bottom_left :
+        top_right :
+        width :
+        height :
+        **kwargs :
+        """
+        quadrangle_patch = m.draw_quadrangle(bottom_left, width, height, top_right, resolution=500)
+        quadrangle_coordinates = quadrangle_patch.get_xy()
+
+        c = SkyCoord(quadrangle_coordinates[:, 0]*u.deg, quadrangle_coordinates[:, 1]*u.deg,
+                     frame=bottom_left.frame, obstime=m.date)
+        mesh = self._coords_to_xyz(c)
+        self.plotter.add_mesh(mesh, **kwargs)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -182,6 +182,7 @@ class SunpyPlotter:
         quadrangle_coordinates = quadrangle_patch.get_xy()
         c = SkyCoord(quadrangle_coordinates[:, 0]*u.deg, quadrangle_coordinates[:, 1]*u.deg,
                      frame='heliographic_stonyhurst', obstime=m.date)
+        c.transform_to(self.coordinate_frame)
         mesh = self._coords_to_xyz(c)
         self.plotter.add_mesh(mesh, **kwargs)
 

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -5,7 +5,8 @@ import pyvista as pv
 
 import astropy.units as u
 from astropy.constants import R_sun
-from sunpy.coordinates import HeliocentricInertial, SkyCoord
+from astropy.coordinates import SkyCoord
+from sunpy.coordinates import HeliocentricInertial
 from sunpy.map.maputils import all_corner_coords_from_map
 
 __all__ = ['SunpyPlotter']
@@ -167,7 +168,7 @@ class SunpyPlotter:
                          **defaults)
         self.plotter.add_mesh(arrow, **kwargs)
 
-    def plot_quadrangle(self, m, bottom_left, top_right, width, height, **kwargs):
+    def plot_quadrangle(self, m, bottom_left, top_right=None, width: u.deg = None, height: u.deg = None, **kwargs):
         """
         Plots a quadrangle on the given map.
         This draws a quadrangle that has corners at ``(bottom_left, top_right)``,
@@ -177,16 +178,22 @@ class SunpyPlotter:
 
         Parameters
         ----------
-        bottom_left :
-        top_right :
-        width :
-        height :
-        **kwargs :
+        bottom_left :`~astropy.coordinates.SkyCoord`
+            The bottom-left coordinate of the quadrangle. It can
+            have shape ``(2,)`` to simultaneously define ``top_right``.
+        top_right : `~astropy.coordinates.SkyCoord`
+            The top-right coordinate of the quadrangle.
+        width : `astropy.units.Quantity`, optional
+            The width of the quadrangle. Required if ``top_right`` is omitted.
+        height : `astropy.units.Quantity`
+            The height of the quadrangle. Required if ``top_right`` is omitted.
+        **kwargs : Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """
-        quadrangle_patch = m.draw_quadrangle(bottom_left, width, height, top_right, resolution=500)
+        quadrangle_patch = m.draw_quadrangle(bottom_left=bottom_left, top_right=top_right,
+                                             width=width, height=height, resolution=500)
         quadrangle_coordinates = quadrangle_patch.get_xy()
-
+        print(quadrangle_coordinates)
         c = SkyCoord(quadrangle_coordinates[:, 0]*u.deg, quadrangle_coordinates[:, 1]*u.deg,
-                     frame=bottom_left.frame, obstime=m.date)
+                     frame='heliographic_stonyhurst', obstime=m.date)
         mesh = self._coords_to_xyz(c)
         self.plotter.add_mesh(mesh, **kwargs)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -178,7 +178,7 @@ class SunpyPlotter:
         **kwargs : Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """
         quadrangle_patch = m.draw_quadrangle(bottom_left=bottom_left, top_right=top_right,
-                                             width=width, height=height, resolution=500)
+                                             width=width, height=height, resolution=1000)
         quadrangle_coordinates = quadrangle_patch.get_xy()
         c = SkyCoord(quadrangle_coordinates[:, 0]*u.deg, quadrangle_coordinates[:, 1]*u.deg,
                      frame='heliographic_stonyhurst', obstime=m.date)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -180,7 +180,6 @@ class SunpyPlotter:
         quadrangle_patch = m.draw_quadrangle(bottom_left=bottom_left, top_right=top_right,
                                              width=width, height=height, resolution=500)
         quadrangle_coordinates = quadrangle_patch.get_xy()
-        print(quadrangle_coordinates)
         c = SkyCoord(quadrangle_coordinates[:, 0]*u.deg, quadrangle_coordinates[:, 1]*u.deg,
                      frame='heliographic_stonyhurst', obstime=m.date)
         mesh = self._coords_to_xyz(c)

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -3,6 +3,7 @@ import functools
 import numpy as np
 import pyvista as pv
 
+import astropy.units as u
 from astropy.constants import R_sun
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import HeliocentricInertial


### PR DESCRIPTION
Adds `draw_quadrangle` from sunpy. I've taken the docstring from sunpy itself as it doesn't change here.
I don't think we need to worry about the `kwargs` which are passed to astropy's `Quadrangle` do we?
If yes, then we need to have a separate `quad_kwargs` or something.

![image](https://user-images.githubusercontent.com/50923538/121787955-fcda1780-cbe6-11eb-807a-2af248f40b8d.png)
