### PR TITLE
Adds clipping of data via clip_interval argument

### DIFF
--- a/changelog/26.feature.rst
+++ b/changelog/26.feature.rst
@@ -1,0 +1,2 @@
+:meth:`~sunkit_pyvista.plotter.SunpyPlotter.plot_map` accepts the keyword ``clip_interval`` as argument, which clips the data
+according to the percentile interval bounded by the two numbers.

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -28,7 +28,7 @@ m = Map(AIA_193_IMAGE)
 # Start by creating a plotter
 plotter = SunpyPlotter()
 # Plot a map
-plotter.plot_map(m, clip_interval=(1,99)*u.percent)
+plotter.plot_map(m, clip_interval=(1, 99)*u.percent)
 # Add an arrow to show the solar rotation axis
 plotter.plot_solar_axis()
 # Plot an arbitrary line

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -28,7 +28,7 @@ m = Map(AIA_193_IMAGE)
 # Start by creating a plotter
 plotter = SunpyPlotter()
 # Plot a map
-plotter.plot_map(m)
+plotter.plot_map(m, clip_interval=(50,99)*u.percent)
 # Add an arrow to show the solar rotation axis
 plotter.plot_solar_axis()
 # Plot an arbitrary line

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -28,7 +28,7 @@ m = Map(AIA_193_IMAGE)
 # Start by creating a plotter
 plotter = SunpyPlotter()
 # Plot a map
-plotter.plot_map(m, clip_interval=(50,99)*u.percent)
+plotter.plot_map(m, clip_interval=(1,99)*u.percent)
 # Add an arrow to show the solar rotation axis
 plotter.plot_solar_axis()
 # Plot an arbitrary line

--- a/examples/skip_plot_map_in_3d.py
+++ b/examples/skip_plot_map_in_3d.py
@@ -28,7 +28,7 @@ m = Map(AIA_193_IMAGE)
 # Start by creating a plotter
 plotter = SunpyPlotter()
 # Plot a map
-plotter.plot_map(m, clip_interval=(1, 99)*u.percent)
+plotter.plot_map(m, clip_interval=(0, 99)*u.percent)
 # Add an arrow to show the solar rotation axis
 plotter.plot_solar_axis()
 # Plot an arbitrary line

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -152,7 +152,6 @@ class SunpyPlotter:
                                  "specified as two numbers.")
         else:
             clim = [0, 1]
-
         self.plotter.add_mesh(mesh, cmap=cmap, clim=clim, **kwargs)
 
     def plot_line(self, coords, **kwargs):

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -137,6 +137,9 @@ class SunpyPlotter:
         ----------
         m : `sunpy.map.Map`
             Map to be plotted.
+        clip_interval : two-element `~astropy.units.Quantity`, optional
+            If provided, the data will be clipped to the percentile
+            interval bounded by the two numbers.
         **kwargs :
             Keyword arguments are handed to `pyvista.Plotter.add_mesh`.
         """

--- a/sunkit_pyvista/tests/test_pyvista.py
+++ b/sunkit_pyvista/tests/test_pyvista.py
@@ -81,6 +81,7 @@ def test_plot_coordinates(plotter):
     expected_center = [-0.5000000149011612, -0.5, 0.7071067690849304]
     assert np.allclose(plotter.plotter.mesh.center, expected_center)
 
+
 def test_clip_interval(aia171_test_map, plotter):
     plotter.plot_map(aia171_test_map, clip_interval=(1, 99)*u.percent)
     clim = plotter._get_clim(data=plotter.plotter.mesh['data'],

--- a/sunkit_pyvista/tests/test_pyvista.py
+++ b/sunkit_pyvista/tests/test_pyvista.py
@@ -71,7 +71,7 @@ def test_plot_line(plotter):
 
 
 def test_clip_interval(aia171_test_map, plotter):
-    plotter.plot_map(aia171_test_map)
+    plotter.plot_map(aia171_test_map, clip_interval=(1, 99)*u.percent)
     clim = plotter._get_clim(data=plotter.plotter.mesh['data'],
                              clip_interval=(1, 99)*u.percent)
     expected_clim = [0.006716044038535769, 0.8024368512284383]
@@ -81,3 +81,7 @@ def test_clip_interval(aia171_test_map, plotter):
     clim = plotter._get_clim(data=plotter.plotter.mesh['data'],
                              clip_interval=(0, 100)*u.percent)
     assert np.allclose(clim, expected_clim)
+
+    with pytest.raises(ValueError, match=r"Clip percentile interval must be "
+                       r"specified as two numbers."):
+        plotter.plot_map(aia171_test_map, clip_interval=(1, 50, 99)*u.percent)

--- a/sunkit_pyvista/tests/test_pyvista.py
+++ b/sunkit_pyvista/tests/test_pyvista.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import pyvista as pv
 
@@ -67,3 +68,16 @@ def test_plot_line(plotter):
     plotter.plot_line(line)
     assert plotter.plotter.mesh.n_cells == 1
     assert plotter.plotter.mesh.n_points == 3
+
+
+def test_clip_interval(aia171_test_map, plotter):
+    plotter.plot_map(aia171_test_map)
+    clim = plotter._get_clim(data=plotter.plotter.mesh['data'],
+                             clip_interval=(1, 99)*u.percent)
+    expected_clim = [0.006716044038535769, 0.8024368512284383]
+    assert np.allclose(clim, expected_clim)
+
+    expected_clim = [0, 1]
+    clim = plotter._get_clim(data=plotter.plotter.mesh['data'],
+                             clip_interval=(0, 100)*u.percent)
+    assert np.allclose(clim, expected_clim)


### PR DESCRIPTION
Similar to how it's done in sunpy, `plot_map()` accepts `clip_interval` as an argument :
```py
plotter.plot_map(m, clip_interval=(1, 99)*u.percent)
```
The above plot produces : 
![image](https://user-images.githubusercontent.com/50923538/123496426-a12b7780-d645-11eb-9cfb-8f2a03163fde.png)
as opposed to no clip interval : 
![image](https://user-images.githubusercontent.com/50923538/123496442-baccbf00-d645-11eb-8233-b8d6d6a6e714.png)

`vmin` and `vmax` is calculated based on the normalized mesh data, should we also allow accepting of `vmin` and `vmax` as separate arguments?