### PR TITLE
Map transpose

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ setup_requires =
 install_requires =
   pfsspy>=0.6.6
   pyvista>=0.31.3
-  sunpy[map]>=3.0.0
+  sunpy[map]>=3.0.1
 
 [options.extras_require]
 tests =

--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -140,7 +140,7 @@ class SunpyPlotter:
         grid.dimensions = [m.data.shape[0] + 1,
                            m.data.shape[1] + 1,
                            1]
-        data = m.data.T.reshape(-1)
+        data = m.data.reshape(-1)
         grid['data'] = m.plot_settings['norm'](data)
         return grid
 


### PR DESCRIPTION
It turns out it was wrong to do this... I compared the current example output of sunkit-pyvista to https://docs.sunpy.org/en/stable/generated/gallery/acquiring_data/2011_06_07_sampledata_overview.html#sphx-glr-generated-gallery-acquiring-data-2011-06-07-sampledata-overview-py to check that removing `.T` is the right thing to do.

Fixes https://github.com/sunpy/sunkit-pyvista/issues/40