### PR TITLE
Improve plotting performance

### DIFF
--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -115,7 +115,7 @@ class SunpyPlotter:
             Coordinates of the camera.
         """
         camera_position = self._coords_to_xyz(coord)
-        pos = tuple(camera_position[0])
+        pos = tuple(camera_position)
         self.plotter.camera.position = pos
 
     @u.quantity_input
@@ -207,10 +207,12 @@ class SunpyPlotter:
         ``radius`` is only considered when a sphere is plotted.
         """
         points = self._coords_to_xyz(coords)
-        if points.shape[0] > 1:
-            point_mesh = pv.Spline(points)
+        if points.ndim == 1:
+            # Single coordinate
+            point_mesh = pv.Sphere(radius=radius, center=points)
         else:
-            point_mesh = pv.Sphere(radius=radius, center=points[0])
+            point_mesh = pv.Spline(points)
+
         color = kwargs.get('color', np.nan)
         point_mesh.add_field_array([color], 'color')
         self.plotter.add_mesh(point_mesh, smooth_shading=True, **kwargs)

--- a/sunkit_pyvista/tests/test_pyvista.py
+++ b/sunkit_pyvista/tests/test_pyvista.py
@@ -40,14 +40,14 @@ def test_coordinate_frame(plotter):
 def test_coord_to_xyz(aia171_test_map, plotter):
     coordinate = aia171_test_map.observer_coordinate
     plot_coord = plotter._coords_to_xyz(coordinate)
-    assert plot_coord.shape[1] == 3
+    assert plot_coord.shape == (3,)
 
 
 def test_camera_position(aia171_test_map, plotter):
     coord = aia171_test_map.observer_coordinate
     camera_position = plotter._coords_to_xyz(coord)
     plotter.set_camera_coordinate(coord)
-    assert (plotter.camera.position == camera_position[0]).all()
+    assert (plotter.camera.position == camera_position).all()
 
 
 def test_set_view_angle(plotter):


### PR DESCRIPTION
I was playing around with plotting a GONG magnetic field map, and noticed the performance wasn't very good. These changes much improve the performance of pyvista when plotting the mesh, I think because it doesn't `ravel()` the data before being given to pyvista.