### PR TITLE
Use pytest.skip() for figure tests

### DIFF
--- a/sunkit_pyvista/tests/conftest.py
+++ b/sunkit_pyvista/tests/conftest.py
@@ -35,7 +35,7 @@ def verify_cache_images(plotter):
     """
     # Image cache is only valid for VTK9 on Linux
     if not VTK9 or platform.system() != 'Linux':
-        return
+        pytest.skip("VTK9 on linux required for this test")
 
     # since each test must contain a unique name, we can simply
     # use the function test to name the image

--- a/sunkit_pyvista/tests/test_plotting.py
+++ b/sunkit_pyvista/tests/test_plotting.py
@@ -1,3 +1,6 @@
+"""
+This file contains figure comparison tests.
+"""
 import numpy as np
 import pfsspy
 import pytest


### PR DESCRIPTION
This is the nicer way to skip the tests, as it is reported as skipped in pytest with a message.