### PR TITLE
default_python isn't valid for publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      default_python: '3.9'
       test_extras: 'dev'
       test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunkit_pyvista'
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,5 @@ jobs:
       )
     needs: [test]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
-    with:
-      test_extras: 'dev'
-      test_command: 'pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs sunkit_pyvista'
     secrets:
       pypi_token: ${{ secrets.pypi_token }}


### PR DESCRIPTION
 I was wondering why it didn't report, this is why.

If we don't test, it hides the problem? (The problem being that the test env using 3.10 by default which will fail). 