### PR TITLE
Add `CartesianPlotter` for visualizing active region magnetic fields in a local Cartesian box

### DIFF
--- a/sunkit_pyvista/plotter.py
+++ b/sunkit_pyvista/plotter.py
@@ -15,9 +15,11 @@ from sunpy.coordinates import HeliocentricInertial, Helioprojective
 from sunpy.coordinates.utils import get_rectangle_coordinates
 from sunpy.map.maputils import all_corner_coords_from_map
 
+from streamtracer import VectorGrid, StreamTracer
+
 from sunkit_pyvista.utils import get_limb_coordinates
 
-__all__ = ["SunpyPlotter"]
+__all__ = ["SunpyPlotter", "CartesianPlotter"]
 
 
 class SunpyPlotter(pv.Plotter):
@@ -584,3 +586,167 @@ class SunpyPlotter(pv.Plotter):
         limb_block.add_field_data(color, "color")
         self.add_mesh(limb_block, color=color, **kwargs)
         self._add_mesh_to_dict(block_name="limbs", mesh=limb_block)
+
+
+class CartesianPlotter(pv.Plotter):
+    """
+    A plotter for 3D data in a Cartesian box.
+
+    This class inherits `pyvista.Plotter`. It is used to visualize 3D vector field lines
+    (e.g., magnetic field lines of solar active regions) traced by `streamtracer`.
+
+    Parameters
+    ----------
+    kwargs : dict
+        All other keyword arguments are passed through to `pyvista.Plotter`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def define_vector_field(self, vectors, *args, **kwargs):
+        """
+        Define a 3D vector field.
+
+        Parameters
+        ----------
+        vectors : ndarray
+            A (nx, ny, nz, 3) array representing the 3D vector field.
+        args: list
+            arguments for `streamtracer.VectorGrid`.
+        kwargs: dict
+            keyword arguments for `streamtracer.VectorGrid`.
+        """
+        if kwargs.get("grid_spacing") is None:
+            if kwargs.get("grid_coords") is None:
+                kwargs["grid_spacing"] = [1, 1, 1]
+        self.grid = VectorGrid(vectors.astype(np.float64), *args, **kwargs)
+        self.xcoords = self.grid.xcoords.astype(np.float64)
+        self.ycoords = self.grid.ycoords.astype(np.float64)
+        self.zcoords = self.grid.zcoords.astype(np.float64)
+        self.x, self.y, self.z = np.meshgrid(self.xcoords, self.ycoords, self.zcoords, indexing="ij")
+
+    def _create_mesh(self):
+        """
+        Create a `pyvista.StructuredGrid` mesh from the 3D vector field.
+        """
+        mesh = pv.StructuredGrid(self.x, self.y, self.z)
+        vectors = self.grid.vectors.transpose(2, 1, 0, 3).reshape(-1, 3)
+        mesh["vectors"] = vectors
+        mesh.active_vectors_name = "vectors"
+        magnitudes = np.linalg.norm(vectors, axis=-1)
+        mesh["magnitudes"] = magnitudes
+        mesh.active_scalars_name = "magnitudes"
+        self.mesh = mesh
+
+    def plot_outline(self, color="black", **kwargs):
+        """
+        Plot the outline of the 3D vector field.
+
+        Parameters
+        ----------
+        color : str, optional
+            The color of the outline.
+            Default is 'black'.
+        kwargs : dict
+            Keyword arguments for `pyvista.Plotter.add_mesh`.
+        """
+        self._create_mesh()
+        self.add_mesh(self.mesh.outline(), color=color, **kwargs)
+
+    def plot_boundary(self, boundary="bottom", component=2, cmap="gray", **kwargs):
+        """
+        Plot the boundary of the 3D vector field.
+
+        Parameters
+        ----------
+        boundary : str, optional
+            The boundary to be plotted.
+            'bottom', 'top', 'left', 'right', 'front', or 'back'.
+            Default is 'bottom'.
+        component : int, optional
+            The component of the vector field to be plotted.
+            0, 1, or 2 for x, y, or z component, respectively.
+            Default is 2.
+        cmap : str, optional
+            The colormap for the boundary.
+            Default is 'gray'.
+        kwargs : dict
+            Keyword arguments for `pyvista.Plotter.add_mesh`.
+        """
+        self._create_mesh()
+        nx, ny, nz = self.mesh.dimensions
+        x_min, y_min, z_min = 0, 0, 0
+        x_max, y_max, z_max = nx - 1, ny - 1, nz - 1
+
+        if boundary == "bottom":
+            subset = (x_min, x_max, y_min, y_max, z_min, z_min)
+        elif boundary == "top":
+            subset = (x_min, x_max, y_min, y_max, z_max, z_max)
+        elif boundary == "left":
+            subset = (x_min, x_min, y_min, y_max, z_min, z_max)
+        elif boundary == "right":
+            subset = (x_max, x_max, y_min, y_max, z_min, z_max)
+        elif boundary == "front":
+            subset = (x_min, x_max, y_min, y_min, z_min, z_max)
+        elif boundary == "back":
+            subset = (x_min, x_max, y_max, y_max, z_min, z_max)
+        else:
+            raise ValueError("Invalid boundary. Choose from 'bottom', 'top', 'left', 'right', 'front', or 'back'.")
+
+        surface = self.mesh.extract_subset(subset).extract_surface()
+        surface.active_vectors_name = "vectors"
+        surface.active_scalars_name = "magnitudes"
+        self.add_mesh(surface, scalars="vectors", component=component, cmap=cmap, lighting=False, **kwargs)
+
+    def plot_field_lines(
+        self,
+        seeds,
+        render_lines_as_tubes=True,
+        radius=1,
+        max_steps=10000,
+        step_size=0.1,
+        seeds_config=dict(show_seeds=False, color="red", point_size=5),
+        **kwargs,
+    ):
+        """
+        Plot field lines traced from seeds using `streamtracer.StreamTracer`.
+
+        Parameters
+        ----------
+        seeds : ndarray
+            A (N, 3) array representing the seeds.
+        render_lines_as_tubes : bool, optional
+            Whether to render field lines as tubes.
+            Default is True.
+        radius : float, optional
+            The radius of the tubes for rendering field lines.
+            Default is 1.
+        max_steps : int, optional
+            The maximum number of steps for tracing field lines.
+            Default is 10000.
+        step_size : float, optional
+            The step size for tracing field lines.
+            Default is 0.1.
+        seeds_config : dict, optional
+            Configuration for plotting seeds.
+            Default is dict(show_seeds=False, color='red', point_size=5).
+        kwargs : dict
+            Keyword arguments for `pyvista.Plotter.add_mesh`.
+        """
+        tracer = StreamTracer(max_steps, step_size)
+        tracer.trace(seeds, self.grid)
+        tracer_xs = []
+        tracer_xs.append(tracer.xs)
+        tracer_xs = [item for sublist in tracer_xs for item in sublist]
+        for i, xl in enumerate(tracer_xs):
+            assert seeds[i] in xl
+            if len(xl) < 2:
+                continue
+            spline = pv.Spline(xl)
+            if render_lines_as_tubes:
+                spline = spline.tube(radius=radius)
+            self.add_mesh(spline, **kwargs)
+        if seeds_config.get("show_seeds"):
+            seeds_config.pop("show_seeds")
+            self.add_mesh(pv.PolyData(seeds), **seeds_config)


### PR DESCRIPTION
Closes https://github.com/sunpy/sunkit-pyvista/issues/194 by adding a new plotter `CartesianPlotter` for active region magnetic fields.

## Description
- This PR introduces `CartesianPlotter`, enabling visualization of active region magnetic fields in a local Cartesian coordinate system.
- This implementation is a first step towards integrating `RobertJaro/NF2` into `sunkit-magex` (see [this issue](https://github.com/sunpy/sunkit-magex/issues/14)).

## Minimal Example
### 1. Analytical Magnetic Field
(Adapted from https://github.com/antyeates1983/flhtools)

#### Define magnetic field array and seed points
```python
import numpy as np

def Bx(x, y, z):
    return x * 0 - 2

def By(x, y, z, t=2):
    return -z - t * (1 - z**2) / (1 + z**2 / 25)**2 / (1 + x**2 / 25)

def Bz(x, y, z):
    return y

nx, ny, nz = 64, 64, 64
x1 = np.linspace(-20, 20, nx)
y1 = np.linspace(-20, 20, ny)
z1 = np.linspace(0, 40, nz)
x, y, z = np.meshgrid(x1, y1, z1, indexing='ij')

bx, by, bz = Bx(x, y, z), By(x, y, z), Bz(x, y, z)
b = np.stack([bx, by, bz], axis=-1)
print(b.shape)  # (64, 64, 64, 3)

x_seed = np.linspace(-10, 10, 10)
y_seed = np.linspace(-10, 10, 5)
seeds = np.array([[x, y, 0] for x in x_seed for y in y_seed])
print(seeds.shape)  # (50, 3)
```

#### Plot
```python
from sunkit_pyvista import CartesianPlotter

plotter = CartesianPlotter()
plotter.define_vector_field(b, grid_coords=(x1, y1, z1))
plotter.show_bounds()
plotter.plot_outline(color='black')
plotter.plot_boundary(show_scalar_bar=False)
plotter.plot_field_lines(seeds, color='blue', radius=0.1,
                         seeds_config=dict(show_seeds=True, color='red', point_size=10))
plotter.camera.azimuth = 210
plotter.camera.elevation = -5
plotter.camera.zoom(0.8)
plotter.show(jupyter_backend='static')
```

![analytical](https://github.com/user-attachments/assets/76ddae02-0d25-4062-8569-b5dd6533abc6)

### 2. Numerical Magnetic Field

Download https://hinode.isee.nagoya-u.ac.jp/nlfff_database/v12/11890/20131106/11890_20131106_003600.nc

#### Define magnetic field array and seed points
```python
import netCDF4

nc = netCDF4.Dataset('11890_20131106_003600.nc', 'r')
x1 = np.array(nc.variables['x'][:])
y1 = np.array(nc.variables['y'][:])
z1 = np.array(nc.variables['z'][:])
bx = np.array(nc.variables['Bx'][:].transpose(2, 1, 0))
by = np.array(nc.variables['By'][:].transpose(2, 1, 0))
bz = np.array(nc.variables['Bz'][:].transpose(2, 1, 0))
nc.close()

b = np.stack([bx, by, bz], axis=-1)
print(b.shape)  # (513, 257, 257, 3)

dx, dy = x1[1] - x1[0], y1[1] - y1[0]
x_seed = np.linspace(x1[0] + 100 * dx, x1[-1] - 100 * dx, 10)
y_seed = np.linspace(y1[0] + 50 * dy, y1[-1] - 50 * dy, 10)
seeds = np.array([[x, y, 0] for x in x_seed for y in y_seed])
print(seeds.shape)  # (100, 3)
```

#### Plot
```python
from sunkit_pyvista import CartesianPlotter

plotter = CartesianPlotter()
plotter.define_vector_field(b, grid_coords=(x1, y1, z1))
plotter.show_bounds()
plotter.plot_outline(color='black')
plotter.plot_boundary(show_scalar_bar=True, clim=(-1000, 1000), 
                      scalar_bar_args=dict(position_x=0))
plotter.plot_field_lines(seeds, color='blue',
                         seeds_config=dict(show_seeds=False))
plotter.camera.azimuth = 210
plotter.camera.elevation = -5
plotter.camera.zoom(0.9)
plotter.show(jupyter_backend='static')
```

![numerical](https://github.com/user-attachments/assets/3641d1a9-8efa-4ca8-a130-72caa87b2f58)

## Feedback
You can test `CartesianPlotter` in [this Colab notebook](https://colab.research.google.com/github/mgjeon/magnetic_field_line/blob/main/example/example_CartesianPlotter_colab.ipynb).

I'm not sure if this API design is appropriate. Also, I want to extend AR visualization to the spherical coordinate system, but I'm uncertain how to approach it. Please feel free to share your thoughts and suggestions.